### PR TITLE
[FE] Fix: 찜한 달인 프로필 경로 수정

### DIFF
--- a/src/components/mypage/BookMarkPro.jsx
+++ b/src/components/mypage/BookMarkPro.jsx
@@ -217,8 +217,9 @@ const BookMarkPro = () => {
                                     <div className="ProProfile">
                                         <img
                                             src={
-                                                pro.profileImage ||
-                                                "/image/profile.svg"
+                                                "https://kr.object.ncloudstorage.com/moeego/profile/" +
+                                                    pro.profileImage ||
+                                                "/image/default.svg"
                                             }
                                             alt={pro.name}
                                         />

--- a/src/css/mypage/BookMarkPro.css
+++ b/src/css/mypage/BookMarkPro.css
@@ -210,12 +210,17 @@
 }
 
 .BookMarkProContainer .BookMarkProWrap .ProListContainer .infoContainer {
-    width: 100%;
-    display: flex;
     box-sizing: border-box;
+    display: flex;
     vertical-align: text-top;
+    width: 100%;
     padding: 10px;
     height: 5em;
+
+    display: -webkit-box; /* Flexbox 대체로 설정 */
+    -webkit-line-clamp: 2; /* 표시할 줄 수 (예: 2줄) */
+    -webkit-box-orient: vertical; /* 텍스트 방향 설정 */
+    overflow: hidden;
 }
 
 .BookMarkProContainer .BookMarkProWrap .ProListContainer .scoreContainer {


### PR DESCRIPTION
# 버그 내용
- 찜한 달인 경로 문제로 인한 프로필 출력 오류

# 수정한 내용
- 찜한 달인 프로필 경로 수정
- 한 줄 소개 출력 CSS 변경

# 상세 내용
- 찜한 달인 프로필 경로 조건에 따라 NCP ObjectStorage와 /image 경로 지정
- 찜한 달인 출력 div에 -webkit-box 사용 출력 텍스트 높이 길이 제한